### PR TITLE
Adding and Removing Libraries to Retrieve Body Data

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,3 @@
 fastapi==0.61.1
 PyJWT~=1.7
 uvicorn~=0.12
-python-multipart==0.0.5

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 fastapi==0.61.1
 PyJWT~=1.7
 uvicorn~=0.12
+pydantic~=1.7


### PR DESCRIPTION
## Summary

In order to get body data with FastAPI, `pydantic` is required. 
On the other hand, we don't need `python-multipart.` 
Therefore, I added pydantic and removed python-multipart.