### PR TITLE
Add Libraries for MySQL Connection and JWT Auth

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,7 @@
 fastapi==0.61.1
 PyJWT~=1.7
+cryptography~=3.2
 uvicorn~=0.12
 pydantic~=1.7
+SQLAlchemy==1.3.20
+mysqlclient~=2.0


### PR DESCRIPTION
## Summary

Adding Libraries for MySQL Connection and JWT Auth.

## Changes

- `requirements.txt`
  - cryptography~=3.2
  - SQLAlchemy==1.3.20
  - mysqlclient~=2.0

## Related Issues

closed #27 